### PR TITLE
Rename to `NoHashHasher`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
-name = "int-hasher"
+name = "nohash-hasher"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
+keywords = ["hash", "hasher", "hashmap"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,12 +22,10 @@
 
 use std::{hash::{BuildHasherDefault, Hasher}, marker::PhantomData};
 
-pub type BuildIntHasher<T> =
-    BuildHasherDefault<IntHasher<T>>;
+pub type BuildIntHasher<T> = BuildHasherDefault<IntHasher<T>>;
 
 /// Type alias which links the `HashMap`'s key type to the `IntHasher`.
-pub type IntMap<K, V> =
-    std::collections::HashMap<K, V, BuildIntHasher<K>>;
+pub type IntMap<K, V> = std::collections::HashMap<K, V, BuildIntHasher<K>>;
 
 /// An `IntHasher` is a *stateless* implementation of `Hasher` which does
 /// not actually hash at all. Using this hasher, one must ensure that it is
@@ -235,84 +233,56 @@ impl Hasher for IntHasher<isize> {
 
 #[cfg(test)]
 mod tests {
-    use std::hash::BuildHasher;
     use super::*;
 
     #[test]
-    fn u8() {
-        let mut h = BuildIntHasher::<u8>::default().build_hasher();
-        h.write_u8(42);
-        assert_eq!(42, h.finish())
-    }
+    fn ok() {
+        let mut h1 = IntHasher::<u8>::default();
+        h1.write_u8(42);
+        assert_eq!(42, h1.finish());
 
-    #[test]
-    fn u16() {
-        let mut h = BuildIntHasher::<u16>::default().build_hasher();
-        h.write_u16(42);
-        assert_eq!(42, h.finish())
-    }
+        let mut h2 = IntHasher::<u16>::default();
+        h2.write_u16(42);
+        assert_eq!(42, h2.finish());
 
-    #[test]
-    fn u32() {
-        let mut h = BuildIntHasher::<u32>::default().build_hasher();
-        h.write_u32(42);
-        assert_eq!(42, h.finish())
-    }
+        let mut h3 = IntHasher::<u32>::default();
+        h3.write_u32(42);
+        assert_eq!(42, h3.finish());
 
-    #[test]
-    fn u64() {
-        let mut h = BuildIntHasher::<u64>::default().build_hasher();
-        h.write_u64(42);
-        assert_eq!(42, h.finish())
-    }
+        let mut h4 = IntHasher::<u64>::default();
+        h4.write_u64(42);
+        assert_eq!(42, h4.finish());
 
-    #[test]
-    fn usize() {
-        let mut h = BuildIntHasher::<usize>::default().build_hasher();
-        h.write_usize(42);
-        assert_eq!(42, h.finish())
-    }
+        let mut h5 = IntHasher::<usize>::default();
+        h5.write_usize(42);
+        assert_eq!(42, h5.finish());
 
-    #[test]
-    fn i8() {
-        let mut h = BuildIntHasher::<i8>::default().build_hasher();
-        h.write_i8(42);
-        assert_eq!(42, h.finish())
-    }
+        let mut h6 = IntHasher::<i8>::default();
+        h6.write_i8(42);
+        assert_eq!(42, h6.finish());
 
-    #[test]
-    fn i16() {
-        let mut h = BuildIntHasher::<i16>::default().build_hasher();
-        h.write_i16(42);
-        assert_eq!(42, h.finish())
-    }
+        let mut h7 = IntHasher::<i16>::default();
+        h7.write_i16(42);
+        assert_eq!(42, h7.finish());
 
-    #[test]
-    fn i32() {
-        let mut h = BuildIntHasher::<i32>::default().build_hasher();
-        h.write_i32(42);
-        assert_eq!(42, h.finish())
-    }
+        let mut h8 = IntHasher::<i32>::default();
+        h8.write_i32(42);
+        assert_eq!(42, h8.finish());
 
-    #[test]
-    fn i64() {
-        let mut h = BuildIntHasher::<i64>::default().build_hasher();
-        h.write_i64(42);
-        assert_eq!(42, h.finish())
-    }
+        let mut h9 = IntHasher::<i64>::default();
+        h9.write_i64(42);
+        assert_eq!(42, h9.finish());
 
-    #[test]
-    fn isize() {
-        let mut h = BuildIntHasher::<isize>::default().build_hasher();
-        h.write_isize(42);
-        assert_eq!(42, h.finish())
+        let mut h10 = IntHasher::<isize>::default();
+        h10.write_isize(42);
+        assert_eq!(42, h10.finish())
     }
 
     #[cfg(debug_assertions)]
     #[test]
     #[should_panic]
-    fn u8_panic() {
-        let mut h = BuildIntHasher::<u8>::default().build_hasher();
+    fn u8_double_usage() {
+        let mut h = IntHasher::<u8>::default();
         h.write_u8(42);
         h.write_u8(43);
     }
@@ -320,8 +290,8 @@ mod tests {
     #[cfg(debug_assertions)]
     #[test]
     #[should_panic]
-    fn u16_panic() {
-        let mut h = BuildIntHasher::<u16>::default().build_hasher();
+    fn u16_double_usage() {
+        let mut h = IntHasher::<u16>::default();
         h.write_u16(42);
         h.write_u16(43);
     }
@@ -329,8 +299,8 @@ mod tests {
     #[cfg(debug_assertions)]
     #[test]
     #[should_panic]
-    fn u32_panic() {
-        let mut h = BuildIntHasher::<u32>::default().build_hasher();
+    fn u32_double_usage() {
+        let mut h = IntHasher::<u32>::default();
         h.write_u32(42);
         h.write_u32(43);
     }
@@ -338,8 +308,8 @@ mod tests {
     #[cfg(debug_assertions)]
     #[test]
     #[should_panic]
-    fn u64_panic() {
-        let mut h = BuildIntHasher::<u64>::default().build_hasher();
+    fn u64_double_usage() {
+        let mut h = IntHasher::<u64>::default();
         h.write_u64(42);
         h.write_u64(43);
     }
@@ -347,9 +317,55 @@ mod tests {
     #[cfg(debug_assertions)]
     #[test]
     #[should_panic]
-    fn usize_panic() {
-        let mut h = BuildIntHasher::<usize>::default().build_hasher();
+    fn usize_double_usage() {
+        let mut h = IntHasher::<usize>::default();
         h.write_usize(42);
         h.write_usize(43);
     }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic]
+    fn i8_double_usage() {
+        let mut h = IntHasher::<i8>::default();
+        h.write_i8(42);
+        h.write_i8(43);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic]
+    fn i16_double_usage() {
+        let mut h = IntHasher::<i16>::default();
+        h.write_i16(42);
+        h.write_i16(43);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic]
+    fn i32_double_usage() {
+        let mut h = IntHasher::<i32>::default();
+        h.write_i32(42);
+        h.write_i32(43);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic]
+    fn i64_double_usage() {
+        let mut h = IntHasher::<i64>::default();
+        h.write_i64(42);
+        h.write_i64(43);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic]
+    fn isize_double_usage() {
+        let mut h = IntHasher::<isize>::default();
+        h.write_isize(42);
+        h.write_isize(43);
+    }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,40 +17,42 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-//! An implementation of `std::hash::Hasher` for usage with `HashMap`s whose domain
-//! are integer types, which do not require hashing at all.
-
 use std::{hash::{BuildHasherDefault, Hasher}, marker::PhantomData};
 
-pub type BuildIntHasher<T> = BuildHasherDefault<IntHasher<T>>;
+/// A `HashMap` with an integer domain, using `NoHashHasher` to perform no hashing at all.
+pub type IntMap<K, V> = std::collections::HashMap<K, V, BuildNoHashHasher<K>>;
 
-/// Type alias which links the `HashMap`'s key type to the `IntHasher`.
-pub type IntMap<K, V> = std::collections::HashMap<K, V, BuildIntHasher<K>>;
+pub type BuildNoHashHasher<T> = BuildHasherDefault<NoHashHasher<T>>;
 
-/// An `IntHasher` is a *stateless* implementation of `Hasher` which does
-/// not actually hash at all. Using this hasher, one must ensure that it is
-/// never used in a stateful way, i.e. a *single* call to `write_*` must be
-/// followed by `finish`. Multiple write-calls will cause errors (debug
-/// builds check this and panic if a violation of this API contract is
-/// detected).
+/// A `NoHashHasher<T>` where `T` is one of
+/// {`u8`, `u16`, `u32`, `u64`, `usize`, `i8`, `i16`, `i32`, `i64`, `isize`}
+/// is a *stateless* implementation of `Hasher` which does not actually hash at all.
+/// By itself this hasher is largely useless, but when used in `HashMap`s whose domain
+/// matches `T` the resulting map operations involving hashing are faster than
+/// with any other possible hashing algorithm.
+///
+/// Using this hasher, one must ensure that it is never used in a stateful way,
+/// i.e. a *single* call to `write_*` must be followed by `finish`. Multiple
+/// write-calls will cause errors (debug builds check this and panic if a violation
+/// of this API contract is detected).
 #[cfg(debug_assertions)]
 #[derive(Copy, Clone, Debug, Default)]
-pub struct IntHasher<T>(u64, bool, PhantomData<T>);
+pub struct NoHashHasher<T>(u64, bool, PhantomData<T>);
 
 #[cfg(not(debug_assertions))]
 #[derive(Copy, Clone, Debug, Default)]
-pub struct IntHasher<T>(u64, PhantomData<T>);
+pub struct NoHashHasher<T>(u64, PhantomData<T>);
 
-impl Hasher for IntHasher<u8> {
+impl Hasher for NoHashHasher<u8> {
     fn finish(&self) -> u64 {
         self.0
     }
     fn write(&mut self, _: &[u8]) {
-        panic!("Invalid use of IntHasher")
+        panic!("Invalid use of NoHashHasher")
     }
     #[cfg(debug_assertions)]
     fn write_u8(&mut self, n: u8) {
-        assert!(!self.1, "IntHasher::write_u8 must be used only once.");
+        assert!(!self.1, "NoHashHasher::write_u8 must be used only once.");
         self.0 = u64::from(n);
         self.1 = true
     }
@@ -60,16 +62,16 @@ impl Hasher for IntHasher<u8> {
     }
 }
 
-impl Hasher for IntHasher<u16> {
+impl Hasher for NoHashHasher<u16> {
     fn finish(&self) -> u64 {
         self.0
     }
     fn write(&mut self, _: &[u8]) {
-        panic!("Invalid use of IntHasher")
+        panic!("Invalid use of NoHashHasher")
     }
     #[cfg(debug_assertions)]
     fn write_u16(&mut self, n: u16) {
-        assert!(!self.1, "IntHasher::write_u16 must be used only once.");
+        assert!(!self.1, "NoHashHasher::write_u16 must be used only once.");
         self.0 = u64::from(n);
         self.1 = true
     }
@@ -79,16 +81,16 @@ impl Hasher for IntHasher<u16> {
     }
 }
 
-impl Hasher for IntHasher<u32> {
+impl Hasher for NoHashHasher<u32> {
     fn finish(&self) -> u64 {
         self.0
     }
     fn write(&mut self, _: &[u8]) {
-        panic!("Invalid use of IntHasher")
+        panic!("Invalid use of NoHashHasher")
     }
     #[cfg(debug_assertions)]
     fn write_u32(&mut self, n: u32) {
-        assert!(!self.1, "IntHasher::write_u32 must be used only once.");
+        assert!(!self.1, "NoHashHasher::write_u32 must be used only once.");
         self.0 = u64::from(n);
         self.1 = true
     }
@@ -98,16 +100,16 @@ impl Hasher for IntHasher<u32> {
     }
 }
 
-impl Hasher for IntHasher<u64> {
+impl Hasher for NoHashHasher<u64> {
     fn finish(&self) -> u64 {
         self.0
     }
     fn write(&mut self, _: &[u8]) {
-        panic!("Invalid use of IntHasher")
+        panic!("Invalid use of NoHashHasher")
     }
     #[cfg(debug_assertions)]
     fn write_u64(&mut self, n: u64) {
-        assert!(!self.1, "IntHasher::write_u64 must be used only once.");
+        assert!(!self.1, "NoHashHasher::write_u64 must be used only once.");
         self.0 = n;
         self.1 = true
     }
@@ -117,16 +119,16 @@ impl Hasher for IntHasher<u64> {
     }
 }
 
-impl Hasher for IntHasher<usize> {
+impl Hasher for NoHashHasher<usize> {
     fn finish(&self) -> u64 {
         self.0
     }
     fn write(&mut self, _: &[u8]) {
-        panic!("Invalid use of IntHasher")
+        panic!("Invalid use of NoHashHasher")
     }
     #[cfg(debug_assertions)]
     fn write_usize(&mut self, n: usize) {
-        assert!(!self.1, "IntHasher::write_usize must be used only once.");
+        assert!(!self.1, "NoHashHasher::write_usize must be used only once.");
         self.0 = n as u64;
         self.1 = true
     }
@@ -136,16 +138,16 @@ impl Hasher for IntHasher<usize> {
     }
 }
 
-impl Hasher for IntHasher<i8> {
+impl Hasher for NoHashHasher<i8> {
     fn finish(&self) -> u64 {
         self.0
     }
     fn write(&mut self, _: &[u8]) {
-        panic!("Invalid use of IntHasher")
+        panic!("Invalid use of NoHashHasher")
     }
     #[cfg(debug_assertions)]
     fn write_i8(&mut self, n: i8) {
-        assert!(!self.1, "IntHasher::write_i8 must be used only once.");
+        assert!(!self.1, "NoHashHasher::write_i8 must be used only once.");
         self.0 = n as u64;
         self.1 = true
     }
@@ -155,16 +157,16 @@ impl Hasher for IntHasher<i8> {
     }
 }
 
-impl Hasher for IntHasher<i16> {
+impl Hasher for NoHashHasher<i16> {
     fn finish(&self) -> u64 {
         self.0
     }
     fn write(&mut self, _: &[u8]) {
-        panic!("Invalid use of IntHasher")
+        panic!("Invalid use of NoHashHasher")
     }
     #[cfg(debug_assertions)]
     fn write_i16(&mut self, n: i16) {
-        assert!(!self.1, "IntHasher::write_i16 must be used only once.");
+        assert!(!self.1, "NoHashHasher::write_i16 must be used only once.");
         self.0 = n as u64;
         self.1 = true
     }
@@ -174,16 +176,16 @@ impl Hasher for IntHasher<i16> {
     }
 }
 
-impl Hasher for IntHasher<i32> {
+impl Hasher for NoHashHasher<i32> {
     fn finish(&self) -> u64 {
         self.0
     }
     fn write(&mut self, _: &[u8]) {
-        panic!("Invalid use of IntHasher")
+        panic!("Invalid use of NoHashHasher")
     }
     #[cfg(debug_assertions)]
     fn write_i32(&mut self, n: i32) {
-        assert!(!self.1, "IntHasher::write_i32 must be used only once.");
+        assert!(!self.1, "NoHashHasher::write_i32 must be used only once.");
         self.0 = n as u64;
         self.1 = true
     }
@@ -193,16 +195,16 @@ impl Hasher for IntHasher<i32> {
     }
 }
 
-impl Hasher for IntHasher<i64> {
+impl Hasher for NoHashHasher<i64> {
     fn finish(&self) -> u64 {
         self.0
     }
     fn write(&mut self, _: &[u8]) {
-        panic!("Invalid use of IntHasher")
+        panic!("Invalid use of NoHashHasher")
     }
     #[cfg(debug_assertions)]
     fn write_i64(&mut self, n: i64) {
-        assert!(!self.1, "IntHasher::write_i64 must be used only once.");
+        assert!(!self.1, "NoHashHasher::write_i64 must be used only once.");
         self.0 = n as u64;
         self.1 = true
     }
@@ -212,16 +214,16 @@ impl Hasher for IntHasher<i64> {
     }
 }
 
-impl Hasher for IntHasher<isize> {
+impl Hasher for NoHashHasher<isize> {
     fn finish(&self) -> u64 {
         self.0
     }
     fn write(&mut self, _: &[u8]) {
-        panic!("Invalid use of IntHasher")
+        panic!("Invalid use of NoHashHasher")
     }
     #[cfg(debug_assertions)]
     fn write_isize(&mut self, n: isize) {
-        assert!(!self.1, "IntHasher::write_isize must be used only once.");
+        assert!(!self.1, "NoHashHasher::write_isize must be used only once.");
         self.0 = n as u64;
         self.1 = true
     }
@@ -237,43 +239,43 @@ mod tests {
 
     #[test]
     fn ok() {
-        let mut h1 = IntHasher::<u8>::default();
+        let mut h1 = NoHashHasher::<u8>::default();
         h1.write_u8(42);
         assert_eq!(42, h1.finish());
 
-        let mut h2 = IntHasher::<u16>::default();
+        let mut h2 = NoHashHasher::<u16>::default();
         h2.write_u16(42);
         assert_eq!(42, h2.finish());
 
-        let mut h3 = IntHasher::<u32>::default();
+        let mut h3 = NoHashHasher::<u32>::default();
         h3.write_u32(42);
         assert_eq!(42, h3.finish());
 
-        let mut h4 = IntHasher::<u64>::default();
+        let mut h4 = NoHashHasher::<u64>::default();
         h4.write_u64(42);
         assert_eq!(42, h4.finish());
 
-        let mut h5 = IntHasher::<usize>::default();
+        let mut h5 = NoHashHasher::<usize>::default();
         h5.write_usize(42);
         assert_eq!(42, h5.finish());
 
-        let mut h6 = IntHasher::<i8>::default();
+        let mut h6 = NoHashHasher::<i8>::default();
         h6.write_i8(42);
         assert_eq!(42, h6.finish());
 
-        let mut h7 = IntHasher::<i16>::default();
+        let mut h7 = NoHashHasher::<i16>::default();
         h7.write_i16(42);
         assert_eq!(42, h7.finish());
 
-        let mut h8 = IntHasher::<i32>::default();
+        let mut h8 = NoHashHasher::<i32>::default();
         h8.write_i32(42);
         assert_eq!(42, h8.finish());
 
-        let mut h9 = IntHasher::<i64>::default();
+        let mut h9 = NoHashHasher::<i64>::default();
         h9.write_i64(42);
         assert_eq!(42, h9.finish());
 
-        let mut h10 = IntHasher::<isize>::default();
+        let mut h10 = NoHashHasher::<isize>::default();
         h10.write_isize(42);
         assert_eq!(42, h10.finish())
     }
@@ -282,7 +284,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn u8_double_usage() {
-        let mut h = IntHasher::<u8>::default();
+        let mut h = NoHashHasher::<u8>::default();
         h.write_u8(42);
         h.write_u8(43);
     }
@@ -291,7 +293,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn u16_double_usage() {
-        let mut h = IntHasher::<u16>::default();
+        let mut h = NoHashHasher::<u16>::default();
         h.write_u16(42);
         h.write_u16(43);
     }
@@ -300,7 +302,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn u32_double_usage() {
-        let mut h = IntHasher::<u32>::default();
+        let mut h = NoHashHasher::<u32>::default();
         h.write_u32(42);
         h.write_u32(43);
     }
@@ -309,7 +311,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn u64_double_usage() {
-        let mut h = IntHasher::<u64>::default();
+        let mut h = NoHashHasher::<u64>::default();
         h.write_u64(42);
         h.write_u64(43);
     }
@@ -318,7 +320,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn usize_double_usage() {
-        let mut h = IntHasher::<usize>::default();
+        let mut h = NoHashHasher::<usize>::default();
         h.write_usize(42);
         h.write_usize(43);
     }
@@ -327,7 +329,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn i8_double_usage() {
-        let mut h = IntHasher::<i8>::default();
+        let mut h = NoHashHasher::<i8>::default();
         h.write_i8(42);
         h.write_i8(43);
     }
@@ -336,7 +338,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn i16_double_usage() {
-        let mut h = IntHasher::<i16>::default();
+        let mut h = NoHashHasher::<i16>::default();
         h.write_i16(42);
         h.write_i16(43);
     }
@@ -345,7 +347,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn i32_double_usage() {
-        let mut h = IntHasher::<i32>::default();
+        let mut h = NoHashHasher::<i32>::default();
         h.write_i32(42);
         h.write_i32(43);
     }
@@ -354,7 +356,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn i64_double_usage() {
-        let mut h = IntHasher::<i64>::default();
+        let mut h = NoHashHasher::<i64>::default();
         h.write_i64(42);
         h.write_i64(43);
     }
@@ -363,7 +365,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn isize_double_usage() {
-        let mut h = IntHasher::<isize>::default();
+        let mut h = NoHashHasher::<isize>::default();
         h.write_isize(42);
         h.write_isize(43);
     }


### PR DESCRIPTION
This better captures what this hasher is doing and discourages its use separate from `HashMap`s.